### PR TITLE
Makefile: Make fiptool build out-of-tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -925,7 +925,7 @@ ENCTOOL			?=	${ENCTOOLPATH}/encrypt_fw${BIN_EXT}
 
 # Variables for use with Firmware Image Package
 FIPTOOLPATH		?=	tools/fiptool
-FIPTOOL			?=	${FIPTOOLPATH}/fiptool${BIN_EXT}
+FIPTOOL			?=	${BUILD_PLAT}/fiptool${BIN_EXT}
 
 # Variables for use with sptool
 SPTOOLPATH		?=	tools/sptool

--- a/tools/fiptool/Makefile
+++ b/tools/fiptool/Makefile
@@ -9,8 +9,9 @@ include ${MAKE_HELPERS_DIRECTORY}build_macros.mk
 include ${MAKE_HELPERS_DIRECTORY}build_env.mk
 
 FIPTOOL ?= fiptool${BIN_EXT}
-PROJECT := $(notdir ${FIPTOOL})
-OBJECTS := fiptool.o tbbr_config.o
+PROJECT := ${FIPTOOL}
+PROJECT_DIR := $(dir ${FIPTOOL})
+OBJECTS := ${PROJECT_DIR}/fiptool.o ${PROJECT_DIR}/tbbr_config.o
 V ?= 0
 OPENSSL_DIR := /usr
 
@@ -62,7 +63,7 @@ ${PROJECT}: ${OBJECTS} Makefile
 	@echo "Built $@ successfully"
 	@${ECHO_BLANK_LINE}
 
-%.o: %.c Makefile
+${PROJECT_DIR}/%.o: %.c Makefile
 	@echo "  HOSTCC  $<"
 	${Q}${HOSTCC} -c ${CPPFLAGS} ${HOSTCCFLAGS} ${INCLUDE_PATHS} $< -o $@
 


### PR DESCRIPTION
Zephyr needs fiptool to build out-of-tree
fix [#51165](https://github.com/zephyrproject-rtos/zephyr/issues/51165)

Signed-off-by: Jaxson Han <jaxson.han@arm.com>