### PR TITLE
make-helpers: Use -T for linker scripts instead of -Wl,--script

### DIFF
--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -533,7 +533,7 @@ ifeq ($($(ARCH)-ld-id),arm-link)
 		$(LDPATHS) $(LIBWRAPPER) $(LDLIBS) $(BL_LIBS) $(OBJS)
 else ifeq ($($(ARCH)-ld-id),gnu-gcc)
 	$$(q)$($(ARCH)-ld) -o $$@ $$(TF_LDFLAGS) $$(LDFLAGS) $$(WRAPPER_FLAGS) $(BL_LDFLAGS) -Wl,-Map=$(MAPFILE) \
-		$(addprefix -Wl$(comma)--script$(comma),$(LINKER_SCRIPTS)) -Wl,--script,$(DEFAULT_LINKER_SCRIPT) \
+		$(addprefix -T ,$(LINKER_SCRIPTS)) -T$(DEFAULT_LINKER_SCRIPT) \
 		$(OBJS) $(LDPATHS) $(LIBWRAPPER) $(LDLIBS) $(BL_LIBS)
 else
 	$$(q)$($(ARCH)-ld) -o $$@ $$(TF_LDFLAGS) $$(LDFLAGS) $$(WRAPPER_FLAGS) $(BL_LDFLAGS) -Map=$(MAPFILE) \


### PR DESCRIPTION
When configured to use picolibc, gcc will insert a default linker script unless another is provided using the -T option. It also always supports -T, so there's no reason to ever use -Wl,--script,

This has been fixed upstream in a slightly different fashion as a part of clang LTO integration, so when Zephyr moves upstream we can drop this patch.